### PR TITLE
bug fixes for BaseNN and BaseML

### DIFF
--- a/BaseML/BaseClassification.py
+++ b/BaseML/BaseClassification.py
@@ -48,7 +48,7 @@ class Classification(baseml):
             if len(para) > 1:
                 self.model = SVC(**para)
             else:
-                self.model = SVC()
+                self.model = SVC(probability=True)
         elif self.algorithm == 'NaiveBayes':
             if len(para) > 1:
                 self.model = GaussianNB(**para)
@@ -135,7 +135,7 @@ class Classification(baseml):
         x_test = self.convert_np(x_test)
 
         if self.algorithm in ['AdaBoost', 'SVM', 'NaiveBayes', 'MLP', 'KNN', 'CART', 'RandomForest']:
-            pred = self.model.predict(x_test)
+            pred = self.model.predict(x_test).astype(int)
             return pred
 
     def metricplot(self, X=None, y_true=None):

--- a/BaseML/BaseCluster.py
+++ b/BaseML/BaseCluster.py
@@ -123,7 +123,7 @@ class Cluster(baseml):  # cluster
             X = self.x_train
         visualizer = InterclusterDistance(self.model)
 
-        visualizer.fit(self.x_train)        # Fit the data to the visualizer
+        visualizer.fit(X)        # Fit the data to the visualizer
         visualizer.show()        # Finalize and render the figure
 
     def plot(self, X=None):
@@ -168,7 +168,7 @@ class Cluster(baseml):  # cluster
         plt.scatter(centers[:, 0], centers[:, 1], c='black', s=20, alpha=0.5)
         # 标出聚类序号
         for i in range(self.model.cluster_centers_.shape[0]):
-            plt.text(centers[:, 0][i]+0.5, y=centers[:, 1][i]+0.5, s=i,
+            plt.text(centers[:, 0][i], y=centers[:, 1][i], s=i,
                      fontdict=dict(color='red', size=10),
                      bbox=dict(facecolor='yellow', alpha=0.2),
                      )
@@ -206,7 +206,7 @@ class Cluster(baseml):  # cluster
 
         if metrics == 'silhouette_score':
             score = silhouette_score(x, self.model.labels_)
-            print('验证轮廓系数为：{}%'.format(score * 100))
+            print('验证轮廓系数为：{}%'.format(score))
         elif metrics == 'calinski_harabasz_score':
             score = calinski_harabasz_score(x, self.model.labels_)
             

--- a/BaseML/BaseRegression.py
+++ b/BaseML/BaseRegression.py
@@ -220,11 +220,8 @@ class Regression(baseml):
         # result = self.inference(self.x_test).squeeze()
         # visualizer.draw(self.y_test, result)
         y_true = y_true.squeeze()
-        visualizer.fit(X, y_true)
-
-        visualizer.score_ = visualizer.estimator.score(X, y_true)
-        result = self.inference(X).squeeze()
-        visualizer.draw(y_true, result)
+        visualizer.fit(self.x_train, self.y_train)  # 1. Fit on TRAIN
+        visualizer.score(X, y_true)  # 2. Score on TEST (X, y_true)
 
         visualizer.show()
 

--- a/BaseML/base.py
+++ b/BaseML/base.py
@@ -309,15 +309,15 @@ class baseml:
             assert len(y) >= 2, "Error Code: -603. The validation set has less than 2 samples and r2-score cannot be calculated."
             score = r2_score(y, y_pred)
             
-            print('验证r2-score为：{}%'.format(score * 100))
+            print('验证r2-score为：{}'.format(score))
             
         elif metrics =='mse':
             score = mean_squared_error(y, y_pred)
-            print('验证均方误差为：{}%'.format(score * 100))
+            print('验证均方误差为：{}'.format(score))
 
         elif metrics =='mae':
             score = mean_absolute_error(y, y_pred)
-            print('验证平均绝对误差为：{}%'.format(score * 100))
+            print('验证平均绝对误差为：{}'.format(score))
 
         else:
             raise AssertionError("Error Code: -307. The '{}' metric is not currently supported.".format(metrics))

--- a/BaseNN/BaseNN/BaseNN.py
+++ b/BaseNN/BaseNN/BaseNN.py
@@ -908,7 +908,7 @@ class nn:
                     optimizer.zero_grad()  # 将梯度初始化为零，即清空过往梯度
                     # print(batch_x.shape,type(batch_x))
                     y_pred = self.model(batch_x)
-                    if self.task_type == 'reg' and (len(batch_y.shape) == 1 or batch_y.shape[-1] == 1):
+                    if self.task_type == 'cls' and (len(batch_y.shape) == 1 or batch_y.shape[-1] == 1):
                         from torch.nn.functional import one_hot
                         batch_y = one_hot(batch_y, self.last_channel).float()
                     # print(batch_y[0],y_pred[0])
@@ -1127,6 +1127,7 @@ class nn:
             sta = torch.load(checkpoint,map_location=torch.device('cpu'))['state_dict']
             self.model.load_state_dict(sta)
 
+        self.model.to(self.device)
         output, hidden = self.model(data, hidden)
         return output, hidden
     
@@ -1243,6 +1244,7 @@ class nn:
         # self.model = torch.load(model_path)
         self.model = torch.load(model_path,map_location=torch.device('cpu'))['state_dict']
 
+        self.model.to(self.device)
         print("载入模型{}成功！".format(model_path))
 
     def print_result(self, result=None):


### PR DESCRIPTION
1.回归有问题，新版本无法完成回归。损失函数不会根据任务类型调整

修改后：
'''python
line 911:
if self.task_type == 'cls' and (len(batch_y.shape) == 1 or batch_y.shape[-1] == 1):
line 912:
from torch.nn.functional import one_hot
line 913:
batch_y = one_hot(batch_y, self.last_channel).float()'''

2.GPU/PC 设备错误 Load函数：

'''python
line 1175:
self.model = torch.load(model_path,map_location=torch.device('cpu'))['state_dict']
line 1176 (新增):
self.model.to(self.device)
line 1177:
print("载入模型{}成功！".format(model_path))'''

3.BaseML分类的推理和 mmedu 不一致 (SVM)

文件： BaseClassification.py
函数： init
50 行
'''
修改后 (添加 probability=True):
self.model = SVC(probability=True)
'''

4.分类推理返回的是浮点数，应该是整数。

文件： BaseClassification.py
函数： inference
行号： 144
'''
修改后 (添加 .astype(int)):
pred = self.model.predict(x_test).astype(int)
'''

5.聚类图 (cluster_plot) 中的数字标签（带黄色背景）位置偏移错误，尤其是在归一化后。

文件： BaseCluster.py
函数： cluster_plot
行号： 204
'''
修改后 (移除 +0.5):
plt.text(centers[:, 0][i], y=centers[:, 1][i], s=i,)
'''

6.均方误差和平均绝对误差被错误地当作百分比输出。

文件： base.py
函数： valid
''' 修改后:
print('验证r2-score为：{}'.format(score))

print('验证均方误差为：{}'.format(score))

print('验证平均绝对误差为：{}'.format(score))
'''